### PR TITLE
Use version instead of branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "^7.3 || ^8.0",
     "illuminate/support": "^5.3 || ^6.0 || ^7.0 || ^8.0",
     "illuminate/routing": "^5.3 || ^6.0 || ^7.0 || ^8.0",
-    "promphp/prometheus_client_php": "dev-main"
+    "promphp/prometheus_client_php": "^2.6.1"
   },
   "require-dev": {
     "ext-apcu": "*",


### PR DESCRIPTION
This should exclude cases where on a major release of `promphp/prometheus_client_php` uninteded/breaking changes will be installed. Also, the current approach of using `dev-main` conflicts with other libs that depend on `promphp/prometheus_client_php:^2.0` if such other projects happen to be installed together with this lib in the same project.