### PR TITLE
Fix routes.php

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1,7 +1,6 @@
 <?php
 
-/** @var \Illuminate\Routing\Route $route */
-$route = Route::get(
+$route = \Illuminate\Support\Facades\Route::get(
     config('prometheus.metrics_route_path'),
     \Mcoirault\LaravelPrometheusExporter\MetricsController::class . '@getMetrics'
 );


### PR DESCRIPTION
# Problem being solved

When there is no alias for `Route`, the route configuration file  `src/routes.php` is not valid.

# Solution

Use `\Illuminate\Support\Facades\Route` instead.